### PR TITLE
Replace Seq with immutable.Seq

### DIFF
--- a/app/actors/PositionSubscriber.scala
+++ b/app/actors/PositionSubscriber.scala
@@ -1,5 +1,6 @@
 package actors
 
+import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import akka.actor.Actor
 import akka.actor.ActorLogging
@@ -50,7 +51,7 @@ class PositionSubscriber(publish: PositionSubscriberUpdate => Unit) extends Acto
       updates ++= points.map(p => p.id -> p)
 
     case Tick =>
-      publish(new PositionSubscriberUpdate(currentArea, updates.values.toSeq))
+      publish(new PositionSubscriberUpdate(currentArea, updates.values.toList))
       updates = Map.empty
 
   }

--- a/app/backend/BotManager.scala
+++ b/app/backend/BotManager.scala
@@ -1,5 +1,6 @@
 package backend
 
+import scala.collection.immutable.Seq
 import akka.actor.{ActorRef, Props, ActorSystem}
 import play.api.libs.json.Json
 import scalax.io.Resource

--- a/app/backend/GeoFunctions.scala
+++ b/app/backend/GeoFunctions.scala
@@ -1,5 +1,6 @@
 package backend
 
+import scala.collection.immutable.Seq
 import models.geojson.LatLng
 
 /**
@@ -96,7 +97,7 @@ object GeoFunctions {
    * @return The clustered points
    */
   def clusterNBoxes(id: String, bbox: BoundingBox, n: Int, points: Seq[PointOfInterest]): Seq[PointOfInterest] = {
-    groupNBoxes(bbox, n, points).toSeq.map {
+    groupNBoxes(bbox, n, points).toList.map {
       case (_, Seq(single)) => single
       // The fold operation here normalises all points to making the west of the bounding box 0, and then takes an average
       case (segment, multiple) =>

--- a/app/backend/Region.scala
+++ b/app/backend/Region.scala
@@ -36,7 +36,7 @@ class Region(regionId: RegionId) extends Actor {
       activeUsers --= obsolete
 
       // Cluster
-      val points = RegionPoints(regionId, GeoFunctions.clusterNBoxes(regionId.name, regionBounds, 4, activeUsers.values.toSeq))
+      val points = RegionPoints(regionId, GeoFunctions.clusterNBoxes(regionId.name, regionBounds, 4, activeUsers.values.toList))
 
       // propagate the points to the summary region via the manager
       context.parent ! points

--- a/app/backend/SummaryRegion.scala
+++ b/app/backend/SummaryRegion.scala
@@ -42,7 +42,7 @@ class SummaryRegion(regionId: RegionId) extends Actor {
 
       // Cluster
       val points = RegionPoints(regionId, GeoFunctions.clusterNBoxes(regionId.name, regionBounds, 4,
-        activePoints.values.flatMap(_.values).toSeq))
+        activePoints.values.flatMap(_.values).toList))
 
       // propagate the points to higher level summary region via the manager
       context.parent ! points

--- a/app/models/geojson/GeoJson.scala
+++ b/app/models/geojson/GeoJson.scala
@@ -1,5 +1,6 @@
 package models.geojson
 
+import scala.collection.immutable.Seq
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import scala.runtime.AbstractPartialFunction


### PR DESCRIPTION
Unfortunately `Seq` is not immutable (the alias points to `scala.collection.Seq`). As messages must be immutable for an Akka based system, I have replaced all occurrences of `Seq` with `immutable.Seq`.

Attention: The tests failed before that change in the same way, so I assume the change is fine ;-)
