### PR TITLE
Update the versions

### DIFF
--- a/app/backend/Main.scala
+++ b/app/backend/Main.scala
@@ -4,7 +4,8 @@ import akka.actor.ActorSystem
 import actors.RegionManagerClient
 import java.net.URL
 import akka.cluster.Cluster
-import com.typesafe.conductr.bundlelib.akka.{ConnectionContext, StatusService, Env}
+import com.typesafe.conductr.lib.akka.ConnectionContext
+import com.typesafe.conductr.bundlelib.akka.{StatusService, Env}
 import com.typesafe.config.ConfigFactory
 
 /**

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 libraryDependencies ++= Seq(
   TypesafeLibrary.akkaOrganization %% "akka-contrib" % "2.3.11",
-  "com.typesafe.conductr" %% "play24-conductr-bundle-lib" % "1.0.1",
+  "com.typesafe.conductr" %% "play24-conductr-bundle-lib" % "1.2.0",
   "com.typesafe.play.extras" %% "play-geojson" % "1.3.0",
   "org.webjars" % "bootstrap" % "3.0.0",
   "org.webjars" % "knockout" % "2.3.0",

--- a/project/project/typesafe.sbt
+++ b/project/project/typesafe.sbt
@@ -1,5 +1,5 @@
 // Update this when a new patch of Reactive Platform is available
-val rpVersion = "15v09p03"
+val rpVersion = "15v09p04"
 
 // Update this when a major version of Reactive Platform is available
 val rpUrl = "https://repo.typesafe.com/typesafe/for-subscribers-only/AEE4D829FC38A3247F251ED25BA45ADD675D48EB"

--- a/tutorial/index.html
+++ b/tutorial/index.html
@@ -861,7 +861,7 @@
 
 <div class="codeSnippet">
   <div class="location">
-    <a href="#code/app/backend/Main.scala:35">Main.scala:35</a>
+    <a href="#code/app/backend/Main.scala:36">Main.scala:36</a>
   </div>
   <pre><code>      val userMetaData = system.actorOf(UserMetaData.props, "userMetaData")</code></pre>
 </div>
@@ -872,7 +872,7 @@
 
 <div class="codeSnippet">
   <div class="location">
-    <a href="#code/app/backend/Main.scala:42">Main.scala:42</a>
+    <a href="#code/app/backend/Main.scala:43">Main.scala:43</a>
   </div>
   <pre><code>      system.actorOf(BotManager.props(regionManagerClient, userMetaData, findUrls(1)))</code></pre>
 </div>
@@ -1426,14 +1426,14 @@ class UserMetaData extends EventsourcedProcessor {
 
 <div class="codeSnippet">
   <div class="location">
-    <a href="#code/app/backend/Main.scala:7">Main.scala:7</a>
+    <a href="#code/app/backend/Main.scala:8">Main.scala:8</a>
   </div>
   <pre><code>import akka.contrib.pattern.ClusterSharding</code></pre>
 </div>
 
 <div class="codeSnippet">
   <div class="location">
-    <a href="#code/app/backend/Main.scala:32">Main.scala:32</a>
+    <a href="#code/app/backend/Main.scala:33">Main.scala:33</a>
   </div>
   <pre><code>
       ClusterSharding(system).start(
@@ -1445,7 +1445,7 @@ class UserMetaData extends EventsourcedProcessor {
 
 <div class="codeSnippet">
   <div class="location">
-    <a href="#code/app/backend/Main.scala:42">Main.scala:42</a>
+    <a href="#code/app/backend/Main.scala:43">Main.scala:43</a>
   </div>
   <pre><code>
       ClusterSharding(system).start(
@@ -1560,7 +1560,7 @@ object SharedJournalHelper {
 
 <div class="codeSnippet">
   <div class="location">
-    <a href="#code/app/backend/Main.scala:30">Main.scala:30</a>
+    <a href="#code/app/backend/Main.scala:31">Main.scala:31</a>
   </div>
   <pre><code>    // This will not be needed with a distributed journal
     SharedJournalHelper.startupSharedJournal(system)

--- a/tutorial/index.html.script
+++ b/tutorial/index.html.script
@@ -834,7 +834,7 @@ class BackendActors @Inject() (system: ActorSystem, configuration: Configuration
     </p>
 
 <<app/backend/Main.scala>>=
-34a
+35a
       val userMetaData = system.actorOf(UserMetaData.props, "userMetaData")
 .
 @
@@ -844,7 +844,7 @@ class BackendActors @Inject() (system: ActorSystem, configuration: Configuration
     </p>
 
 <<app/backend/Main.scala>>=
-42c
+43c
       system.actorOf(BotManager.props(regionManagerClient, userMetaData, findUrls(1)))
 .
 @
@@ -1379,13 +1379,13 @@ class UserMetaDataProvider @Inject() (system: ActorSystem) extends Provider[Acto
     </p>
 
 <<app/backend/Main.scala>>=
-6a
+7a
 import akka.contrib.pattern.ClusterSharding
 .
 @
 
 <<app/backend/Main.scala>>=
-31a
+32a
 
       ClusterSharding(system).start(
         typeName = UserMetaData.shardName,
@@ -1396,7 +1396,7 @@ import akka.contrib.pattern.ClusterSharding
 @
 
 <<app/backend/Main.scala>>=    
-42c
+43c
 
       ClusterSharding(system).start(
         typeName = UserMetaData.shardName,
@@ -1508,7 +1508,7 @@ object SharedJournalHelper {
     </p>
 
 <<app/backend/Main.scala>>=
-29a
+30a
     // This will not be needed with a distributed journal
     SharedJournalHelper.startupSharedJournal(system)
 


### PR DESCRIPTION
Also solves a problem re RM not being able to be run with ConductR 1.1 (we used to provide the wrong host header in an older conducti-bundle-lib).