### PR TITLE
Update sbt-conductr to 1.5.2 and sbt-conductr-sandbox to 1.4.3

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,5 +21,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.1.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-bintray-bundle" % "1.0.1")
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.2.1")
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.2.1")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.5.2")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.4.3")


### PR DESCRIPTION
This is to obtain both plugins which contains sbt-bundle 1.3.2.

This particular version of sbt-bundle contains fixes to allow reactive maps bundle to be built from Windows machine.