### PR TITLE
Use sbt-conductr 2.0.1

### DIFF
--- a/app/backend/Main.scala
+++ b/app/backend/Main.scala
@@ -25,7 +25,8 @@ object Main {
   def main(args: Array[String]): Unit = {
     val config = Env.asConfig
     val systemName = sys.env.getOrElse("BUNDLE_SYSTEM", "application")
-    implicit val system = ActorSystem(systemName, config.withFallback(ConfigFactory.load()))
+    val systemVersion = sys.env.getOrElse("BUNDLE_SYSTEM_VERSION", "1")
+    implicit val system = ActorSystem(s"$systemName-$systemVersion", config.withFallback(ConfigFactory.load()))
 
     if (Cluster(system).selfRoles.exists(r => r.startsWith("backend"))) {
       system.actorOf(RegionManager.props(), "regionManager")

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,6 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 libraryDependencies ++= Seq(
   TypesafeLibrary.akkaOrganization %% "akka-contrib" % "2.3.11",
-  "com.typesafe.conductr" %% "play24-conductr-bundle-lib" % "1.2.0",
   "com.typesafe.play.extras" %% "play-geojson" % "1.3.0",
   "org.webjars" % "bootstrap" % "3.0.0",
   "org.webjars" % "knockout" % "2.3.0",
@@ -39,19 +38,15 @@ BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 50.MB
 BundleKeys.endpoints := Map(
   "akka-remote" -> Endpoint("tcp"),
-  "web" -> Endpoint("http", services=Set(URI("http://:9000")))
+  "web" -> Endpoint("http", services = Set(URI("http://:9000")))
 )
 BundleKeys.roles := Set("dmz")
-BundleKeys.startCommand ++= Seq(
-  "-Dhttp.address=$WEB_BIND_IP",
-  "-Dhttp.port=$WEB_BIND_PORT",
-  "-Dakka.cluster.roles.1=frontend"
-)
+BundleKeys.startCommand += "-Dakka.cluster.roles.1=frontend"
 
 // Bundles that override the main one
 
 lazy val BackendRegion = config("backend-region").extend(Bundle)
-SbtBundle.bundleSettings(BackendRegion)
+BundlePlugin.bundleSettings(BackendRegion)
 inConfig(BackendRegion)(Seq(
   normalizedName := "reactive-maps-backend-region",
   BundleKeys.endpoints := Map("akka-remote" -> Endpoint("tcp")),
@@ -66,7 +61,7 @@ inConfig(BackendRegion)(Seq(
 ))
 
 lazy val BackendSummary = config("backend-summary").extend(BackendRegion)
-SbtBundle.bundleSettings(BackendSummary)
+BundlePlugin.bundleSettings(BackendSummary)
 inConfig(BackendSummary)(Seq(
   normalizedName := "reactive-maps-backend-summary",
   BundleKeys.startCommand :=
@@ -88,7 +83,7 @@ BintrayBundle.settings(BackendRegion)
 BintrayBundle.settings(BackendSummary)
 
 
-//
+// Root project
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -19,10 +19,6 @@ reactiveMaps.bots.totalNumberOfBots=75
 # The actors module
 play.modules.enabled += "actors.Actors"
 
-# ConductR configuration - automatically registers startup
-play.application.loader = "com.typesafe.conductr.bundlelib.play.ConductRApplicationLoader"
-play.modules.enabled += "com.typesafe.conductr.bundlelib.play.ConductRLifecycleModule"
-
 # Secret key
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
@@ -36,7 +32,7 @@ play.i18n.langs=["en"]
 # Akka configuration
 akka {
 
-  loglevel = INFO
+  loglevel = "INFO"
   
   actor.provider = "akka.cluster.ClusterActorRefProvider"
   

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,6 +20,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.1.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-bintray-bundle" % "1.0.1")
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.5.2")
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.4.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-bintray-bundle" % "1.0.2")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.0.1")

--- a/tutorial/index.html
+++ b/tutorial/index.html
@@ -861,7 +861,7 @@
 
 <div class="codeSnippet">
   <div class="location">
-    <a href="#code/app/backend/Main.scala:36">Main.scala:36</a>
+    <a href="#code/app/backend/Main.scala:37">Main.scala:37</a>
   </div>
   <pre><code>      val userMetaData = system.actorOf(UserMetaData.props, "userMetaData")</code></pre>
 </div>
@@ -872,7 +872,7 @@
 
 <div class="codeSnippet">
   <div class="location">
-    <a href="#code/app/backend/Main.scala:43">Main.scala:43</a>
+    <a href="#code/app/backend/Main.scala:44">Main.scala:44</a>
   </div>
   <pre><code>      system.actorOf(BotManager.props(regionManagerClient, userMetaData, findUrls(1)))</code></pre>
 </div>
@@ -1433,7 +1433,7 @@ class UserMetaData extends EventsourcedProcessor {
 
 <div class="codeSnippet">
   <div class="location">
-    <a href="#code/app/backend/Main.scala:33">Main.scala:33</a>
+    <a href="#code/app/backend/Main.scala:34">Main.scala:34</a>
   </div>
   <pre><code>
       ClusterSharding(system).start(
@@ -1445,7 +1445,7 @@ class UserMetaData extends EventsourcedProcessor {
 
 <div class="codeSnippet">
   <div class="location">
-    <a href="#code/app/backend/Main.scala:43">Main.scala:43</a>
+    <a href="#code/app/backend/Main.scala:44">Main.scala:44</a>
   </div>
   <pre><code>
       ClusterSharding(system).start(
@@ -1475,7 +1475,7 @@ class UserMetaData extends EventsourcedProcessor {
 
 <div class="codeSnippet">
   <div class="location">
-    <a href="#code/conf/application.conf:88">application.conf:88</a>
+    <a href="#code/conf/application.conf:84">application.conf:84</a>
   </div>
   <pre><code>
   persistence {
@@ -1560,7 +1560,7 @@ object SharedJournalHelper {
 
 <div class="codeSnippet">
   <div class="location">
-    <a href="#code/app/backend/Main.scala:31">Main.scala:31</a>
+    <a href="#code/app/backend/Main.scala:32">Main.scala:32</a>
   </div>
   <pre><code>    // This will not be needed with a distributed journal
     SharedJournalHelper.startupSharedJournal(system)
@@ -1599,23 +1599,23 @@ object SharedJournalHelper {
     </p>
 
     <p>
-      For any application that will target ConductR you first need to bring in
-      <a href="#code/project/plugins.sbt" class="shortcut">a couple of plugins</a>, namely
-      <a href="https://github.com/sbt/sbt-conductr" target="_blank">sbt-conductr</a> and
-      <a href="https://github.com/typesafehub/sbt-conductr-sandbox" target="_blank">sbt-conductr-sandbox</a>. You will also need to have installed
-      <a href="https://www.docker.com/" target="_blank">Docker</a> in order to run ConductR within the
+      For any application that will target ConductR you first need to add the sbt plugin
+      <a href="https://github.com/typesafehub/sbt-conductr" target="_blank">sbt-conductr</a> to your
+      <a href="#code/project/plugins.sbt" class="shortcut">project/plugins.sbt</a>. You will also need to have installed
+      <a href="https://www.docker.com/" target="_blank">Docker</a> and the
+      <a href="https://github.com/typesafehub/conductr-cli" target="_blank">conductr-cli</a> in order to run a local ConductR cluster within the
       sandbox.
     </p>
 
     <p>
-      sbt-conductr actually brings in another plugin named <a href="https://github.com/sbt/sbt-bundle" target="_blank">sbt-bundle</a> and between them, you declare some
+      sbt-conductr actually brings in another sbt auto plugin named <a href="https://github.com/typesafehub/sbt-conductr/blob/master/src/main/scala/com/lightbend/conductr/sbt/BundlePlugin.scala" target="_blank">BundlePlugin</a> and between them, you declare some
       <a href="#code/build.sbt" class="shortcut">settings</a> required for deploying your application.
       You then load and run a "bundle" which is the
       unit of deployment for ConductR. A bundle is a zip file with the hash of its contents encoded in its name.
     </p>
 
     <p>
-      sbt-conductr-sandbox allows you to deploy your application to a single-noded version of ConductR for the
+      The sandbox allows you to deploy your application on a local ConductR cluster for the
       purposes of testing. The sandbox provides a visualization of the loaded and running bundles, application log
       reporting within the comfort of sbt and proxying of your services. You can therefore get your application
       perfectly prepared for deploying into more production-like environments that run ConductR (such as EC2).
@@ -1625,12 +1625,11 @@ object SharedJournalHelper {
       In terms of modifying ReactiveMaps very little is required. The essential requirement is that your application
       must <a href="#code/app/backend/Main.scala" class="shortcut">signal ConductR that is it ready</a> upon having
       started up.
-      Note the lines that obtain a BUNDLE_SYSTEM to be used
-      as a system name and then the latter lines that signal ConductR that the app has started up. Also note that this
-      code is only required when running pure Akka applications such as the backend of ReactiveMaps. For Play, things
-      are even simpler and only require that you modify your
-      <a href="#code/conf/application.conf" class="shortcut">application.conf</a> to enable a ConductRApplicationLoader and
-      a ConductRLifecycleModule. Both the Akka and Play approaches utilize a library named
+      Note the lines that obtain a BUNDLE_SYSTEM and BUNDLE_SYSTEM_VERSION. These environment variables are set in the context of ConductR.
+      In our case we use these information to specify the actor system name. The latter lines signal to ConductR that the app has started up.
+      Also note that this code is only required when running pure Akka applications such as the backend of ReactiveMaps.
+      For Play, no configuration or code change is necessary. Both the Akka and Play approaches utilize a library named
+
       <a href="#code/build.sbt" class="shortcut">conductr-bundle-lib</a>. That's it!
     </p>
 

--- a/tutorial/index.html.script
+++ b/tutorial/index.html.script
@@ -834,7 +834,7 @@ class BackendActors @Inject() (system: ActorSystem, configuration: Configuration
     </p>
 
 <<app/backend/Main.scala>>=
-35a
+36a
       val userMetaData = system.actorOf(UserMetaData.props, "userMetaData")
 .
 @
@@ -844,7 +844,7 @@ class BackendActors @Inject() (system: ActorSystem, configuration: Configuration
     </p>
 
 <<app/backend/Main.scala>>=
-43c
+44c
       system.actorOf(BotManager.props(regionManagerClient, userMetaData, findUrls(1)))
 .
 @
@@ -1385,7 +1385,7 @@ import akka.contrib.pattern.ClusterSharding
 @
 
 <<app/backend/Main.scala>>=
-32a
+33a
 
       ClusterSharding(system).start(
         typeName = UserMetaData.shardName,
@@ -1396,7 +1396,7 @@ import akka.contrib.pattern.ClusterSharding
 @
 
 <<app/backend/Main.scala>>=    
-43c
+44c
 
       ClusterSharding(system).start(
         typeName = UserMetaData.shardName,
@@ -1426,7 +1426,7 @@ import akka.contrib.pattern.ClusterSharding
     </p>
 
 <<conf/application.conf>>= 
-87a
+83a
 
   persistence {
     journal.plugin = "akka.persistence.journal.leveldb-shared"
@@ -1508,7 +1508,7 @@ object SharedJournalHelper {
     </p>
 
 <<app/backend/Main.scala>>=
-30a
+31a
     // This will not be needed with a distributed journal
     SharedJournalHelper.startupSharedJournal(system)
 
@@ -1548,23 +1548,23 @@ object SharedJournalHelper {
     </p>
 
     <p>
-      For any application that will target ConductR you first need to bring in
-      <a href="#code/project/plugins.sbt" class="shortcut">a couple of plugins</a>, namely
-      <a href="https://github.com/sbt/sbt-conductr" target="_blank">sbt-conductr</a> and
-      <a href="https://github.com/typesafehub/sbt-conductr-sandbox" target="_blank">sbt-conductr-sandbox</a>. You will also need to have installed
-      <a href="https://www.docker.com/" target="_blank">Docker</a> in order to run ConductR within the
+      For any application that will target ConductR you first need to add the sbt plugin
+      <a href="https://github.com/typesafehub/sbt-conductr" target="_blank">sbt-conductr</a> to your
+      <a href="#code/project/plugins.sbt" class="shortcut">project/plugins.sbt</a>. You will also need to have installed
+      <a href="https://www.docker.com/" target="_blank">Docker</a> and the
+      <a href="https://github.com/typesafehub/conductr-cli" target="_blank">conductr-cli</a> in order to run a local ConductR cluster within the
       sandbox.
     </p>
 
     <p>
-      sbt-conductr actually brings in another plugin named <a href="https://github.com/sbt/sbt-bundle" target="_blank">sbt-bundle</a> and between them, you declare some
+      sbt-conductr actually brings in another sbt auto plugin named <a href="https://github.com/typesafehub/sbt-conductr/blob/master/src/main/scala/com/lightbend/conductr/sbt/BundlePlugin.scala" target="_blank">BundlePlugin</a> and between them, you declare some
       <a href="#code/build.sbt" class="shortcut">settings</a> required for deploying your application.
       You then load and run a "bundle" which is the
       unit of deployment for ConductR. A bundle is a zip file with the hash of its contents encoded in its name.
     </p>
 
     <p>
-      sbt-conductr-sandbox allows you to deploy your application to a single-noded version of ConductR for the
+      The sandbox allows you to deploy your application on a local ConductR cluster for the
       purposes of testing. The sandbox provides a visualization of the loaded and running bundles, application log
       reporting within the comfort of sbt and proxying of your services. You can therefore get your application
       perfectly prepared for deploying into more production-like environments that run ConductR (such as EC2).
@@ -1574,12 +1574,11 @@ object SharedJournalHelper {
       In terms of modifying ReactiveMaps very little is required. The essential requirement is that your application
       must <a href="#code/app/backend/Main.scala" class="shortcut">signal ConductR that is it ready</a> upon having
       started up.
-      Note the lines that obtain a BUNDLE_SYSTEM to be used
-      as a system name and then the latter lines that signal ConductR that the app has started up. Also note that this
-      code is only required when running pure Akka applications such as the backend of ReactiveMaps. For Play, things
-      are even simpler and only require that you modify your
-      <a href="#code/conf/application.conf" class="shortcut">application.conf</a> to enable a ConductRApplicationLoader and
-      a ConductRLifecycleModule. Both the Akka and Play approaches utilize a library named
+      Note the lines that obtain a BUNDLE_SYSTEM and BUNDLE_SYSTEM_VERSION. These environment variables are set in the context of ConductR.
+      In our case we use these information to specify the actor system name. The latter lines signal to ConductR that the app has started up.
+      Also note that this code is only required when running pure Akka applications such as the backend of ReactiveMaps.
+      For Play, no configuration or code change is necessary. Both the Akka and Play approaches utilize a library named
+
       <a href="#code/build.sbt" class="shortcut">conductr-bundle-lib</a>. That's it!
     </p>
 


### PR DESCRIPTION
Use `sbt-conductr` 2.0.1. With this version `sbt-conductr-sandbox` isn't necessary to add anymore to the `plugins.sbt`. This version also simplies the `application.conf` and `build.sbt`.

PR has been acceptance tested on a ConductR cluster.