### PR TITLE
Introduce service name to Reactive Maps frontend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ BundleKeys.system := "reactive-maps"
 
 BundleKeys.endpoints := Map(
   "akka-remote" -> Endpoint("tcp"),
-  "web" -> Endpoint("http", services = Set(URI("http://:9000")))
+  "web" -> Endpoint("http", 0, serviceName = Some("reactive-maps-frontend"), services = Some(Set(URI("http://:9000"))), acls = None)
 )
 BundleKeys.roles := Set("dmz")
 BundleKeys.startCommand += "-Dakka.cluster.roles.1=frontend"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,4 +21,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.1.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-bintray-bundle" % "1.0.2")
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.9")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.20")


### PR DESCRIPTION
This will allow ConductR service locator to redirect to ReactiveMaps frontend based on its service name.

Also upgrade to sbt-conductr 2.1.20.