### PR TITLE
Convert to ACLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 jdk: oraclejdk8
 
 script:
-  - sbt test activatorRunTutorial activatorGenerateTutorial
+  - sudo sbt test activatorRunTutorial activatorGenerateTutorial
   - git diff --quiet tutorial/index.html || (echo "index.html has been updated directly, do not do this, edit tutorial/index.html, then use https://github.com/typesafehub/activator-tutorial-generator to generate the new index.html" && false)
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: scala
 jdk: oraclejdk8
 
 script:
-  - sudo sbt test activatorRunTutorial activatorGenerateTutorial
-  - git diff --quiet tutorial/index.html || (echo "index.html has been updated directly, do not do this, edit tutorial/index.html, then use https://github.com/typesafehub/activator-tutorial-generator to generate the new index.html" && false)
+  - sbt test #activatorRunTutorial activatorGenerateTutorial
+  - #git diff --quiet tutorial/index.html || (echo "index.html has been updated directly, do not do this, edit tutorial/index.html, then use https://github.com/typesafehub/activator-tutorial-generator to generate the new index.html" && false)
 
 before_script:
   - printf "resolvers += \"Typesafe repository\" at \"http://repo.typesafe.com/typesafe/releases/\"\n\naddSbtPlugin(\"com.typesafe.sbt\" %%%% \"sbt-activator-tutorial-generator\" %% \"1.0.3\")" > project/activator-tutorial-generator.sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
+dist: trusty
+sudo: required
+
 language: scala
 
 jdk: oraclejdk8
 
 script:
-  - sbt test #activatorRunTutorial activatorGenerateTutorial
-  - #git diff --quiet tutorial/index.html || (echo "index.html has been updated directly, do not do this, edit tutorial/index.html, then use https://github.com/typesafehub/activator-tutorial-generator to generate the new index.html" && false)
+  - sbt test activatorRunTutorial activatorGenerateTutorial
+  - git diff --quiet tutorial/index.html || (echo "index.html has been updated directly, do not do this, edit tutorial/index.html, then use https://github.com/typesafehub/activator-tutorial-generator to generate the new index.html" && false)
 
 before_script:
   - printf "resolvers += \"Typesafe repository\" at \"http://repo.typesafe.com/typesafe/releases/\"\n\naddSbtPlugin(\"com.typesafe.sbt\" %%%% \"sbt-activator-tutorial-generator\" %% \"1.0.3\")" > project/activator-tutorial-generator.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -34,9 +34,16 @@ normalizedName in Bundle := "reactive-maps-frontend"
 BundleKeys.system := "reactive-maps"
 
 BundleKeys.endpoints := Map(
-  "akka-remote" -> Endpoint("tcp"),
-  "web" -> Endpoint("http", 0, serviceName = Some("reactive-maps-frontend"), services = Some(Set(URI("http://:9000"))), acls = None)
+  "web" -> Endpoint("http", 0, serviceName = "reactive-maps-frontend", acls =
+    RequestAcl(
+      Http(
+        "^/".r
+      )
+    )
+  ),
+  "akka-remote" -> Endpoint("tcp", 0)
 )
+
 BundleKeys.roles := Set("dmz")
 BundleKeys.startCommand += "-Dakka.cluster.roles.1=frontend"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,5 +20,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.1.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-bintray-bundle" % "1.0.2")
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.20")
+addSbtPlugin("com.typesafe.sbt" % "sbt-bintray-bundle" % "1.2.0")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.2.9")


### PR DESCRIPTION
...and also update the plugins to the latest.

Converting to ACLs permits RM to work on ConductR 2.1. ConductR 2.0 also supports ACLs, but 1.1 doesn't. So this change will mean a departure for 1.1 users and they'll have to use an older RM if required.